### PR TITLE
chore(MEET-COMMAND): Cria Deployment

### DIFF
--- a/infrastructure/k8s/meet-command_deployments.yaml
+++ b/infrastructure/k8s/meet-command_deployments.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    field.cattle.io/creatorId: u-yax2jhjoym
+    field.cattle.io/publicEndpoints: '[{"addresses":["3.83.237.204"],"port":443,"protocol":"HTTPS","serviceName":"command-meet:meet-command","ingressName":"command-meet:command-meet","hostname":"command-meet.k8s.aws.instruct.com.br","allNodes":true}]'
+  labels:
+    cattle.io/creator: norman
+    workload.user.cattle.io/workloadselector: deployment-command-meet-meet-command
+  name: meet-command
+  namespace: command-meet
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      workload.user.cattle.io/workloadselector: deployment-command-meet-meet-command
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        cattle.io/timestamp: "2020-10-19T18:47:43Z"
+        field.cattle.io/ports: '[[{"containerPort":8000,"dnsName":"meet-command","kind":"ClusterIP","name":"8000tcp02","protocol":"TCP","sourcePort":0}]]'
+      labels:
+        workload.user.cattle.io/workloadselector: deployment-command-meet-meet-command
+    spec:
+      containers:
+        - args:
+            - uvicorn
+            - main:app
+            - --host
+            - 0.0.0.0
+            - --port
+            - "8000"
+          env:
+            - name: DEBUG
+              value: "False"
+            - name: MATTERMOST_TOKEN
+              value: nk4ku3t8ntbhjjt7p7rfba9edo
+          image: docker.pkg.github.com/instruct-br/mattermost-command-meet/mattermost-meet-command:latest
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ping
+              port: 8000
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 60
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: meet-command
+          ports:
+            - containerPort: 8000
+              name: 8000tcp02
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ping
+              port: 8000
+              scheme: HTTP
+            initialDelaySeconds: 2
+            periodSeconds: 2
+            successThreshold: 2
+            timeoutSeconds: 2
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {}
+            privileged: false
+            procMount: Default
+            readOnlyRootFilesystem: false
+            runAsNonRoot: false
+          stdin: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          tty: true
+      dnsPolicy: ClusterFirst
+      imagePullSecrets:
+        - name: github
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30


### PR DESCRIPTION
    O `meet-command` não tem um backup do deployment.
    Este backup configura os deployments necessários.